### PR TITLE
Parse utc date instead of local

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function dateFilter(date, format)
     var obj;
     Array.prototype.push.apply(args, arguments);
     try {
-        obj = moment(date);
+        obj = moment.utc(date);
     } catch (err) {
         errs.push(err);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,8 @@ var nunjucks        = require('nunjucks');
 var moment          = require('moment');
 
 var testDate        = '2015-03-21';
-var testMoment      = moment(testDate);
-var testMomentPlus  = moment(testDate).add(7, 'days');
+var testMoment      = moment.utc(testDate);
+var testMomentPlus  = moment.utc(testDate).add(7, 'days');
 var testFilterName  = 'custom_filter';
 var testFormat      = 'YYYY';
 var testDefFormat   = 'YYYY-MM-DD';


### PR DESCRIPTION
When I use this filter my output is off by a day. My local offset is -7. This pr defaults moment to use utc http://momentjs.com/docs/#/parsing/utc/
